### PR TITLE
feat: 🎸 Added showDialog prop to SpotifyAuth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ dist
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.idea/

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Here's some props that can be used to customize the button. Please enter your ow
 | `noLogo`        |          | `false`                                    | Removes the Spotify logo from the button.                                                                                                                                             |
 | `localStorage`  |          | `false`                                    | Uses `window.localStorage` as a method to store the token. Note that localstorage does not have an expiry.                                                                            |
 | `noCookie`      |          | `false`                                    | When true, it does not store the auth token in a cookie named `SpotifyAuthToken`                                                                                                      |
+| `showDialog`      |          | `false`                                  | Whether or not to force the user to approve the app again if they’ve already done so. If false (default), a user who has already approved the application may be automatically redirected to the URI specified by redirect_uri. If true, the user will not be automatically redirected and will have to approve the app again.                                                                                                      |
 
 ### SpotifyAuthListener
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test": "run-s test:unit test:lint test:build",
     "test:build": "run-s build",
     "test:lint": "eslint .",
-    "test:unit": "cross-env CI=1 react-scripts test --env=jsdom-fourteen",
+    "test:unit": "cross-env CI=1 react-scripts test",
     "test:watch": "react-scripts test --env=jsdom",
     "predeploy": "cd example && yarn install && yarn run build",
     "deploy": "gh-pages -d example/build",

--- a/src/SpotifyAuth.jsx
+++ b/src/SpotifyAuth.jsx
@@ -39,7 +39,8 @@ class SpotifyAuth extends Component {
     window.location = getRedirectUri(
       this.props.clientID,
       this.props.scopes,
-      this.props.redirectUri
+      this.props.redirectUri,
+      this.props.showDialog
     )
   }
 
@@ -67,6 +68,7 @@ SpotifyAuth.propTypes = {
   title: t.string,
   noLogo: t.bool,
   noCookie: t.bool,
+  showDialog: t.bool,
   localStorage: t.bool
 }
 
@@ -77,7 +79,8 @@ SpotifyAuth.defaultProps = {
   title: 'Continue with Spotify',
   localStorage: false,
   noLogo: false,
-  noCookie: false
+  noCookie: false,
+  showDialog: false,
 }
 
 export default SpotifyAuth

--- a/src/generateUrl.js
+++ b/src/generateUrl.js
@@ -1,10 +1,11 @@
-const getRedirectUrl = (clientID, scopes, redirectUri) => {
+const getRedirectUrl = (clientID, scopes, redirectUri, showDialog) => {
   return (
     'https://accounts.spotify.com/authorize?response_type=token' +
     `&client_id=${clientID}` +
     `&scope=${scopes.join('%20')}` +
     `&redirect_uri=${redirectUri}` +
-    '&show_dialog=true'
+    '&show_dialog=' +
+    Boolean(showDialog)
   )
 }
 

--- a/src/generateUrl.test.js
+++ b/src/generateUrl.test.js
@@ -8,7 +8,7 @@ describe('generateUrl', () => {
     const redirectUri = 'http://localhost:3000/callback'
 
     const goodUrl =
-      'https://accounts.spotify.com/authorize?response_type=token&client_id=1a70ba777fec4ffd9633c0c418bdcf39&scope=user-read-private%20user-read-email&redirect_uri=http://localhost:3000/callback&show_dialog=true'
+      'https://accounts.spotify.com/authorize?response_type=token&client_id=1a70ba777fec4ffd9633c0c418bdcf39&scope=user-read-private%20user-read-email&redirect_uri=http://localhost:3000/callback&show_dialog=false'
 
     expect(generateUrl(clientID, scopes, redirectUri)).toEqual(goodUrl)
   })
@@ -18,8 +18,18 @@ describe('generateUrl', () => {
     const redirectUri = 'http://localhost:3000/callback'
 
     const goodUrl =
-      'https://accounts.spotify.com/authorize?response_type=token&client_id=1a70ba777fec4ffd9633c0c418bdcf39&scope=ugcImageUpload%20userFollowRead%20userFollowModify%20userReadRecentlyPlayed%20userTopRead%20userReadPlaybackPosition%20userLibraryRead%20userLibraryModify%20userReadPlaybackState%20userReadCurrentlyPlaying%20userModifyPlaybackState%20playlistReadCollaborative%20playlistModifyPrivate%20playlistModifyPublic%20playlistReadPrivate%20streaming%20appRemoteControl%20userReadEmail%20userReadPrivate&redirect_uri=http://localhost:3000/callback&show_dialog=true'
+      'https://accounts.spotify.com/authorize?response_type=token&client_id=1a70ba777fec4ffd9633c0c418bdcf39&scope=ugcImageUpload%20userFollowRead%20userFollowModify%20userReadRecentlyPlayed%20userTopRead%20userReadPlaybackPosition%20userLibraryRead%20userLibraryModify%20userReadPlaybackState%20userReadCurrentlyPlaying%20userModifyPlaybackState%20playlistReadCollaborative%20playlistModifyPrivate%20playlistModifyPublic%20playlistReadPrivate%20streaming%20appRemoteControl%20userReadEmail%20userReadPrivate&redirect_uri=http://localhost:3000/callback&show_dialog=false'
 
     expect(generateUrl(clientID, scopes, redirectUri)).toEqual(goodUrl)
+  })
+  it('generates fine with show_dialog true', () => {
+    const clientID = '1a70ba777fec4ffd9633c0c418bdcf39'
+    const scopes = [Scopes.userReadPrivate, Scopes.userReadEmail]
+    const redirectUri = 'http://localhost:3000/callback'
+
+    const goodUrl =
+      'https://accounts.spotify.com/authorize?response_type=token&client_id=1a70ba777fec4ffd9633c0c418bdcf39&scope=user-read-private%20user-read-email&redirect_uri=http://localhost:3000/callback&show_dialog=true'
+
+    expect(generateUrl(clientID, scopes, redirectUri, true)).toEqual(goodUrl)
   })
 })

--- a/src/getHash.js
+++ b/src/getHash.js
@@ -5,7 +5,7 @@ export const getHash = () => {
         .split('&')
         .reduce((initial, item) => {
           if (item) {
-            var parts = item.split('=')
+            const parts = item.split('=')
             initial[parts[0]] = decodeURIComponent(parts[1])
           }
           return initial


### PR DESCRIPTION
When showDialog is false (default) a user who has already approved the
application will be redirected. If true then they will have to approve
the app again.

BREAKING CHANGE: 🧨 showDialog is now false by default.


Note: Also fixes broken travis builds due to `--env=jsdom-fourteen`